### PR TITLE
feat(gulp): separate dev watchers from production build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,12 +4,14 @@ import gulpSass from 'gulp-sass'
 
 const sass = gulpSass(dartSass)
 
+// Compile JS
 export function js(done) {
     src('src/js/app.js')
         .pipe(dest('build/js'))
     done();
 }
 
+// Compile CSS
 export function css ( done ) {
     src('src/scss/app.scss', {sourcemaps: true})
         .pipe( sass().on('error', sass.logError) )
@@ -18,9 +20,15 @@ export function css ( done ) {
     done()
 }
 
+// Development Watchers
 export function dev() {
     watch('src/scss/**/*.scss', css)
     watch('src/js/**/*.js', js)
 }
 
-export default series(js, css, dev)
+
+// Prod Build
+export const build = series(js, css)
+
+// Dev Build
+export default series(build, dev)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "sass": "sass src/scss:build/css",
-    "dev": "gulp"
+    "dev": "gulp",
+    "build": "gulp build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Added 'build' task for production to compile JS and CSS
- Kept 'dev' task with watchers for local development
- Updated package.json scripts: 'dev' for development, 'build' for production
- Allows Netlify deployment without hanging on watchers